### PR TITLE
README: available in stock kernel in Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ This forks also makes it possible to use the nix sandbox!
 Run and install nix as user without root permissions. Nix-user-chroot requires
 user namespaces to perform its task (available since linux 3.8). Note that this
 is not available for unprivileged users in some Linux distributions such as
-Red Hat Linux, CentOS and Archlinux when using the stock kernel. It should be
-available in Ubuntu and Debian.
+Red Hat Linux, CentOS when using the stock kernel. It should be
+available in Ubuntu, Debian and Arch Linux.
 
 ## Check if your kernel supports user namespaces for unprivileged users
 


### PR DESCRIPTION
Hi,

It's true that a few years ago user namespaces were not enabled in the stock kernel, but it is now (see [issue](https://bugs.archlinux.org/task/36969)).

```
$ zgrep CONFIG_USER_NS /proc/config.gz
CONFIG_USER_NS=y
CONFIG_USER_NS_UNPRIVILEGED=y
```

Kernel config: https://github.com/archlinux/svntogit-packages/blame/85a93920af2d3fffff676e90c5560089496cba81/trunk/config#L200-L201

Cheers,
Pierre