### PR TITLE
Bind-mount /run/opengl-driver/lib for CUDA/OpenGL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,20 @@ The nix config is not in `/etc/nix` but in `/nix/etc/nix`, so that you can
 modify it. This is done with the `NIX_CONF_DIR`, which you can override at any
 time.
 
+Libraries and applications from Nixpkgs with OpenGL or CUDA support need to
+load libraries from /run/opengl-driver/lib. For convenience, nix-user-chroot
+will bind mount /nix/var/nix/opengl-driver/lib (if it exists) to this location.
+You will still need to link the system libraries here, as their original
+locations are distro-dependent. For example, for CUDA support on Ubuntu 20.04:
+
+```console
+$ mkdir -p /nix/var/nix/opengl-driver/lib
+$ ln -s /usr/lib/x86_64-linux-gnu/libcuda.so.1 /nix/var/nix/opengl-driver/lib
+```
+
+If this directory didn't exist when you first entered the nix user chroot, you
+will need to reenter for /run/opengl-driver/lib to be mounted.
+
 ## Whishlist
 
 These are features the author would like to see, let me know, if you want to work

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-use nix;
 use nix::mount::{mount, MsFlags};
 use nix::sched::{unshare, CloneFlags};
 use nix::sys::signal::{kill, Signal};

--- a/src/mkdtemp.rs
+++ b/src/mkdtemp.rs
@@ -3,7 +3,6 @@ use std::env;
 use std::ffi::OsString;
 use std::os::unix::ffi::OsStringExt;
 use std::path::PathBuf;
-use std::ptr;
 
 mod ffi {
     extern "C" {
@@ -18,7 +17,7 @@ pub fn mkdtemp(template: &str) -> nix::Result<PathBuf> {
     buf.push(b'\0'); // make a c string
 
     let res = unsafe { ffi::mkdtemp(buf.as_mut_ptr() as *mut libc::c_char) };
-    if res == ptr::null_mut() {
+    if res.is_null() {
         Err(nix::Error::Sys(Errno::last()))
     } else {
         buf.pop(); // strip null byte


### PR DESCRIPTION
Fixes https://github.com/nix-community/nix-user-chroot/issues/31

This is implemented by allowing manual bind-mounts before the toplevel dirs are mounted. The bind mounting logic is now recursive, to allow for mounting siblings of any such previously mounted paths.

Currently, this functionality only exists to provide the user-owned /run/opengl-driver/lib bind mount alongside the host system's /run contents. However, it may be used for masking other paths in the future. For example, we could bind mount /nix/etc/nix/nix.conf to /etc/nix/nix.conf and do away with the need for the NIX_CONF_DIR override.