### PR TITLE
tests: resolve profile user via getpwuid

### DIFF
--- a/tests/path_config.rs
+++ b/tests/path_config.rs
@@ -173,9 +173,10 @@ paths = ["{target}"]
 fn profile_mount() {
     let env = TestEnv::new();
 
-    let user = std::env::var("USER")
-        .or_else(|_| std::env::var("LOGNAME"))
-        .expect("need $USER or $LOGNAME to locate the per-user profile");
+    let user = nix::unistd::User::from_uid(nix::unistd::getuid())
+        .unwrap()
+        .expect("current uid has no passwd entry")
+        .name;
 
     // Build the profile symlink chain nix-user-chroot expects:
     //   <nixdir>/var/nix/profiles/per-user/<user>/profile -> profile-1


### PR DESCRIPTION
The Nix build sandbox does not set $USER or $LOGNAME, so the
profile_mount test panicked there even though the binary itself does
not need these variables. Look up the username the same way the
binary does so the test works wherever the binary works.
