### PR TITLE
publish: create release before matrix jobs run

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,10 +5,20 @@ on:
       - '*'
 
 jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: gh release create "${GITHUB_REF_NAME}" --title "${GITHUB_REF_NAME}" --notes ""
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   build:
     name: Publish binaries
+    needs: create-release
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - target: x86_64-unknown-linux-musl

--- a/scripts/create-release.sh
+++ b/scripts/create-release.sh
@@ -70,10 +70,11 @@ git pull "git@github.com:${REPO}" "$MAIN_BRANCH"
 git tag "${version}"
 git push origin "${version}"
 
-# Wait for the publish workflow to create the release, then add notes.
-# upload-release-action creates a bare release with no title/body.
-echo "Waiting for publish workflow to create the release..."
-while ! gh release view "${version}" --repo "${REPO}" >/dev/null 2>&1; do
+# The publish workflow creates an empty release first, then matrix jobs
+# upload assets. Wait for at least one asset so we know the workflow
+# actually ran before we set the notes.
+echo "Waiting for publish workflow to upload assets..."
+while [[ "$(gh release view "${version}" --repo "${REPO}" --json assets --jq '.assets | length' 2>/dev/null || echo 0)" == "0" ]]; do
   sleep 5
 done
 


### PR DESCRIPTION

upload-release-action's race handling is unreliable: when all three
matrix jobs finish at the same time, each sees no release, each tries
to create one, and the losers' fallback GET-by-tag hits GitHub's
eventual consistency window and 404s. This took down the 2.1.1 publish.

Create the release once in a dedicated job that gates the matrix, so
the upload action only ever has to attach assets. Also set fail-fast
to false so one transient upload error does not cancel siblings.

The release script now waits for assets rather than release existence,
since the release is created up front with empty notes.


